### PR TITLE
Updates for rails 3.2.12 support, explicit name spaces and updating sour...

### DIFF
--- a/lib/generators/glass.rb
+++ b/lib/generators/glass.rb
@@ -2,7 +2,7 @@ require 'rails/generators/base'
 
 module Glass
   module Generators
-    class Base < Rails::Generators::Base #:nodoc:
+    class Base < ::Rails::Generators::NamedBase #:nodoc:
       def self.source_root
         @_glass_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'glass', generator_name, 'templates'))
       end

--- a/lib/generators/glass/install/install_generator.rb
+++ b/lib/generators/glass/install/install_generator.rb
@@ -4,9 +4,13 @@ require 'rails/generators/migration'
 
 module Glass
   module Generators
-    class InstallGenerator < Base
-      include Rails::Generators::Migration
+    class InstallGenerator < ::Rails::Generators::Base
+      include ::Rails::Generators::Migration
       argument :user_model, type: :string, default: "User"
+
+      def self.source_root
+        @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+      end
 
       def create_configuration_file
         copy_file("google-oauth.yml", "config/google-api-keys.yml")

--- a/lib/generators/glass/model/model_generator.rb
+++ b/lib/generators/glass/model/model_generator.rb
@@ -6,6 +6,11 @@ module Glass
   module Generators
     class ModelGenerator < Base
       argument :model_name, type: :string
+
+      def self.source_root
+        @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+      end
+      
       def copy_glass_templates
         unless File.directory?("app/models/glass/")
           empty_directory("app/models/glass")


### PR DESCRIPTION
Hey, 

I updated for rails 3.2.12 support. Had to add explicit name space support and the proper source path for the generator templates. 

I briefly tested this. 

_Sam
