### PR TITLE
Ease of use

### DIFF
--- a/lib/generators/glass/install/templates/glass_timeline_item_migration.rb
+++ b/lib/generators/glass/install/templates/glass_timeline_item_migration.rb
@@ -13,6 +13,7 @@ class CreateGlassTimelineItems < ActiveRecord::Migration
       t.string :glass_content_type
       t.text :glass_content
       t.datetime :display_time
+      t.integer :parent_id
 
       t.timestamps
     end

--- a/lib/glass/timeline_item.rb
+++ b/lib/glass/timeline_item.rb
@@ -15,6 +15,7 @@ module Glass
 
     belongs_to :google_account
 
+    before_destroy {|obj| obj.mirror_delete}
 
     ## i'd use cattr_accessor, but unfortunately
     ## ruby has some very crappy class variables, which


### PR DESCRIPTION
This PR simplifies tieing AR models to the actual TimelineItems on your glass. If you destroy the TimelineItem in your database, you should remove it from the device's timeline so that it does not get stranded, and the parent_id allows you to retrieve your model when you get a TimelineItem back from Mirror.
